### PR TITLE
グループ編集機能の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
+
   def index
   end
 
@@ -20,10 +22,19 @@ class GroupsController < ApplicationController
   end
 
   def update
+    if @group.update(group_params)
+      redirect_to root_path, notice: "グループを更新しました"
+    else
+      render :edit
+    end
   end
 
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [] )
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,25 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group}

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,2 +1,3 @@
 .wrapper
   = render 'shared/side_bar'
+  = render 'shared/main_chat'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,31 +1,32 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: "グループ名を入力してください"
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        -# %label.chat-group-form__label チャットメンバー
-        = f.label "チャットメンバー", class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        -# %input.chat-group-form__action-btn{'data-disable-with': "Save", name: "commit", type: "submit", value: "Save"}/
-        = f.submit class: 'chat-group-form__action-btn'
+  = render 'form', { group: @group}
+  -# = form_for @group do |f|
+  -#   - if @group.errors.any?
+  -#     .chat-group-form__errors
+  -#       %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+  -#       %ul
+  -#         - @group.errors.full_messages.each do |message|
+  -#           %li= message
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#       -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
+  -#       = f.label :name, class: 'chat-group-form__label'
+  -#     .chat-group-form__field--right
+  -#       -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+  -#       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: "グループ名を入力してください"
+  -#   .chat-group-form__field
+  -#     / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#       -# %label.chat-group-form__label チャットメンバー
+  -#       = f.label "チャットメンバー", class: 'chat-group-form__label'
+  -#     .chat-group-form__field--right
+  -#       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+  -#       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+  -#       = f.collection_check_boxes :user_ids, User.all, :id, :name
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#     .chat-group-form__field--right
+  -#       -# %input.chat-group-form__action-btn{'data-disable-with': "Save", name: "commit", type: "submit", value: "Save"}/
+  -#       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/shared/_main_chat.html.haml
+++ b/app/views/shared/_main_chat.html.haml
@@ -6,7 +6,7 @@
       .header__left__member
         Member:
     .header__right
-      = link_to edit_group_path(current_user.id), class: "header__right__btn" do
+      = link_to "#", class: "header__right__btn" do
         Edit
   .contents
     .contents__log1

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -10,7 +10,7 @@
   .sidebar__main
     - current_user.groups.each do |group|
       .sidebar__main__group1
-        = link_to '#' do
+        = link_to group_messages_path(group) do
           .sidebar__main__group1__name
             = group.name
           .sidebar__main__group1__message


### PR DESCRIPTION
# What
チャットグループの名前、メンバーを編集する機能を実装する。/groups/1/messagesへのpassは記述したが、messageファイルの編集はまだ行わない。(urlを直接入力する必要がある)

# Why
ユーザーが属しているチャットグループの情報を編集できるようにするため。